### PR TITLE
Support more capitalized string formats

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,8 +24,8 @@ var objectKeys = Object.keys || function (obj) {
 };
 
 function dashCase(str) {
-  return str.replace(/([A-Z])/g, function ($1) {
-    return '-' + $1.toLowerCase();
+  return str.replace(/[A-Z](?:(?=[^A-Z])|[A-Z]*(?=[A-Z][^A-Z]|$))/g, function (s, i) {
+    return (i > 0 ? '-' : '') + s.toLowerCase();
   });
 }
 

--- a/test/dash.js
+++ b/test/dash.js
@@ -28,6 +28,22 @@ test('string', function (t) {
   t.equal(dasherize('oneTwo'), 'one-two');
 });
 
+test('string all caps', function(t) {
+  t.plan(1);
+  t.equal(dasherize('CONSTX'), 'constx');
+});
+
+test('string pascal case', function(t) {
+  t.plan(1);
+  t.equal(dasherize('TestOne'), 'test-one');
+});
+
+test('strings with acronym', function(t) {
+  t.plan(2);
+  t.equal(dasherize('inCIA'), 'in-cia');
+  t.equal(dasherize('isMLBAllStar'), 'is-mlb-all-star');
+})
+
 test('date', function (t) {
   t.plan(1);
   var d = new Date();


### PR DESCRIPTION
First off, thanks so much for this library! It was truly wonderful to find this, already written and ready to be dropped in.

However, the code didn't work with a couple of my string formats (for example, PascalCase got an extra leading hyphen), so I updated the regex to be a bit more sophisticated and added tests for the newly supported formats. 

Hopefully these changes can get merged in. I'd love to go back to depending on your library directly rather than my fork!